### PR TITLE
Int bytes

### DIFF
--- a/qsum/data/tests/test_specific_types.py
+++ b/qsum/data/tests/test_specific_types.py
@@ -1,12 +1,9 @@
-# pylint: disable=redefined-outer-name
-# pylint: disable=missing-function-docstring
-# pylint: disable=wildcard-import
-# pylint: disable=unused-wildcard-import
+# pylint: disable=redefined-outer-name,missing-function-docstring,wildcard-import,unused-wildcard-import
 
 """Some type specific tests that are hard to do in test_by_type"""
 from qsum.core.constants import ChecksumCollection
 from qsum.core.exceptions import QSumInvalidDataTypeException
-from qsum.core.logic import checksum, Checksum
+from qsum.core.logic import checksum
 
 # noinspection PyUnresolvedReferences
 from qsum.tests.helpers import *

--- a/qsum/data/tests/test_to_bytes_custom.py
+++ b/qsum/data/tests/test_to_bytes_custom.py
@@ -1,8 +1,10 @@
+# pylint: disable=wildcard-import,unused-wildcard-import,redefined-outer-name
 from qsum.data.to_bytes_custom import int_to_bytes
 # noinspection PyUnresolvedReferences
 from qsum.tests.helpers import *
 
 
-def test_integer_conversion(range_2_16):
-    all_byte_values = list(map(repr, range_2_16))
+def test_integer_conversion_to_bytes(range_2_16):
+    """Verify integers get unique byte strings"""
+    all_byte_values = list(map(int_to_bytes, range_2_16))
     assert len(all_byte_values) == len(set(all_byte_values)), "Every integer should have a unique byte value"

--- a/qsum/data/tests/test_to_bytes_custom.py
+++ b/qsum/data/tests/test_to_bytes_custom.py
@@ -1,0 +1,8 @@
+from qsum.data.to_bytes_custom import int_to_bytes
+# noinspection PyUnresolvedReferences
+from qsum.tests.helpers import *
+
+
+def test_integer_conversion(range_2_16):
+    all_byte_values = list(map(repr, range_2_16))
+    assert len(all_byte_values) == len(set(all_byte_values)), "Every integer should have a unique byte value"

--- a/qsum/data/to_bytes_custom.py
+++ b/qsum/data/to_bytes_custom.py
@@ -7,6 +7,8 @@ from qsum.data.to_bytes import bytes_from_repr
 def int_to_bytes(obj: int) -> bytes:
     """Convert int's in to the most compact byte representation possible
 
+    CURRENTLY UNUSED, while cleverly packing integers tightly it's actually ~5x slower then just calling repr
+
     Args:
         obj: integer to convert to bytes
 

--- a/qsum/data/to_bytes_custom.py
+++ b/qsum/data/to_bytes_custom.py
@@ -1,5 +1,19 @@
 """Specialized to_bytes methods for specific types"""
+import math
+
 from qsum.data.to_bytes import bytes_from_repr
+
+
+def int_to_bytes(obj: int) -> bytes:
+    """Convert int's in to the most compact byte representation possible
+
+    Args:
+        obj: integer to convert to bytes
+
+    Returns:
+        bytes representing integer
+    """
+    return obj.to_bytes(1 if obj == 0 else math.floor((math.log2(abs(obj)) + 1) / 8 + 1), byteorder='big', signed=True)
 
 
 def complex_to_bytes(obj) -> bytes:


### PR DESCRIPTION
Create a PR to save this code, but it isn't actually turned on for checksums. Would be a nice optional feature at some point to reduce the memory size of large integer lists during checksum computation. 

Addresses #41 