### PR TITLE
Test improvements

### DIFF
--- a/qsum/core/tests/test_logic.py
+++ b/qsum/core/tests/test_logic.py
@@ -34,7 +34,7 @@ def test_sha_lengths(hash_algo, hash_length):
 
 @pytest.mark.parametrize('value', ('abc', '123', ('1', '2', '3')))
 def test_checkum_hex(value):
-    assert checksum(value).hex() == checksum_hex((value))
+    assert checksum(value).hex() == checksum_hex(value)
 
 
 @pytest.mark.xfail(raises=QSumInvalidTypeException, strict=True)

--- a/qsum/data/tests/test_specific_types.py
+++ b/qsum/data/tests/test_specific_types.py
@@ -75,7 +75,7 @@ def test_nested_changing_dict():
     assert checksum(dict_1) != checksum(dict_2)
 
 
-def test_multi_key_type_dict():
+def test_multi_key_type_dict_comparison():
     dict_1 = {'a': 10, 2: 20, 3.0: 30}
     dict_2 = {2: 20, 3.0: 30, 'a': 10}
     assert checksum(dict_1) == checksum(dict_2)
@@ -96,10 +96,16 @@ def test_checksum_collection():
     checksum(checksum_collection)
 
 
-@pytest.mark.parametrize('depth', range(0, 90))
+# keep this right near the limit of the current depth so we know when we've made the stock more complex
+@pytest.mark.parametrize('depth', range(0, 100))
 def test_deep_nested_dict(depth):
     """Ensure deeply nested dicts can be checksummed"""
     nested_dict = {'foo': 'abc'}
     for key in range(0, depth):
         nested_dict = {key: deepcopy(nested_dict)}
     assert len(checksum(nested_dict)) == DEFAULT_BYTES_IN_CHECKSUM
+
+
+def test_long_list(range_2_16):
+    long_list = list(range_2_16)
+    checksum(long_list)

--- a/qsum/data/tests/test_specific_types.py
+++ b/qsum/data/tests/test_specific_types.py
@@ -97,7 +97,7 @@ def test_checksum_collection():
 
 
 # keep this right near the limit of the current depth so we know when we've made the stock more complex
-@pytest.mark.parametrize('depth', range(0, 100))
+@pytest.mark.parametrize('depth', range(0, 90))
 def test_deep_nested_dict(depth):
     """Ensure deeply nested dicts can be checksummed"""
     nested_dict = {'foo': 'abc'}

--- a/qsum/data/tests/test_specific_types.py
+++ b/qsum/data/tests/test_specific_types.py
@@ -97,7 +97,7 @@ def test_checksum_collection():
 
 
 # keep this right near the limit of the current depth so we know when we've made the stock more complex
-@pytest.mark.parametrize('depth', range(0, 90))
+@pytest.mark.parametrize('depth', range(0, 100))
 def test_deep_nested_dict(depth):
     """Ensure deeply nested dicts can be checksummed"""
     nested_dict = {'foo': 'abc'}

--- a/qsum/data/tests/test_specific_types.py
+++ b/qsum/data/tests/test_specific_types.py
@@ -1,10 +1,10 @@
 # pylint: disable=redefined-outer-name,missing-function-docstring,wildcard-import,unused-wildcard-import
 
 """Some type specific tests that are hard to do in test_by_type"""
-from qsum.core.constants import ChecksumCollection
-from qsum.core.exceptions import QSumInvalidDataTypeException
-from qsum.core.logic import checksum
+from copy import deepcopy
 
+from qsum.core.constants import ChecksumCollection, DEFAULT_BYTES_IN_CHECKSUM
+from qsum.core.exceptions import QSumInvalidDataTypeException
 # noinspection PyUnresolvedReferences
 from qsum.tests.helpers import *
 
@@ -94,3 +94,12 @@ def test_singleton_constant(obj):
 def test_checksum_collection():
     checksum_collection = ChecksumCollection()
     checksum(checksum_collection)
+
+
+@pytest.mark.parametrize('depth', range(1, 100))
+def test_deep_nested_dict(depth):
+    """Ensure deeply nested dicts can be checksummed"""
+    nested_dict = {'foo': 1}
+    for key in range(0, depth):
+        nested_dict = {key: deepcopy(nested_dict)}
+    assert len(checksum(nested_dict)) == DEFAULT_BYTES_IN_CHECKSUM

--- a/qsum/data/tests/test_specific_types.py
+++ b/qsum/data/tests/test_specific_types.py
@@ -97,7 +97,8 @@ def test_checksum_collection():
 
 
 # keep this right near the limit of the current depth so we know when we've made the stock more complex
-@pytest.mark.parametrize('depth', range(0, 100))
+# note older minor versions of python 3.x are the limiting factor
+@pytest.mark.parametrize('depth', range(0, 90))
 def test_deep_nested_dict(depth):
     """Ensure deeply nested dicts can be checksummed"""
     nested_dict = {'foo': 'abc'}

--- a/qsum/data/tests/test_specific_types.py
+++ b/qsum/data/tests/test_specific_types.py
@@ -96,10 +96,10 @@ def test_checksum_collection():
     checksum(checksum_collection)
 
 
-@pytest.mark.parametrize('depth', range(1, 100))
+@pytest.mark.parametrize('depth', range(0, 90))
 def test_deep_nested_dict(depth):
     """Ensure deeply nested dicts can be checksummed"""
-    nested_dict = {'foo': 1}
+    nested_dict = {'foo': 'abc'}
     for key in range(0, depth):
         nested_dict = {key: deepcopy(nested_dict)}
     assert len(checksum(nested_dict)) == DEFAULT_BYTES_IN_CHECKSUM

--- a/qsum/examples/cprofile_long_list.py
+++ b/qsum/examples/cprofile_long_list.py
@@ -7,7 +7,7 @@ from qsum import checksum
 
 def main():
     """main method"""
-    long_list = list(range(0, 100000))
+    long_list = list(range(0, 1000000))
     print(checksum(long_list).hex())
 
 

--- a/qsum/examples/cprofile_long_list.py
+++ b/qsum/examples/cprofile_long_list.py
@@ -1,0 +1,15 @@
+"""Performance test that has been instrumental in collection optimizations"""
+
+import cProfile
+
+from qsum import checksum
+
+
+def main():
+    """main method"""
+    long_list = list(range(0, 100000))
+    print(checksum(long_list).hex())
+
+
+if __name__ == "__main__":
+    cProfile.run('main()')


### PR DESCRIPTION
When adding performance tests the 'reduce' call was found to be quite slow and given the sorted nature of some of the operations was fairly pointless.

Checksumming of long integer lists is ~10x faster with these changes.